### PR TITLE
Added AcbVector support struct

### DIFF
--- a/src/ArbNumerics.jl
+++ b/src/ArbNumerics.jl
@@ -131,7 +131,7 @@ using  GenericSVD
 using  LinearAlgebra
 import LinearAlgebra: tr, det, transpose, transpose!, norm, lu, ldlt,
                       cholesky, tril, triu, eigvals, svdvals, floatmin2,
-                      mul!, rmul!, lmul!, eigvecs, svd, eigen
+                      mul!, rmul!, lmul!, eigvecs, svd, eigen, dot
 
 export tr, det, transpose, transpose!, norm, mul!, lmul!, rmul!, lu, ldlt,
        cholesky, tril, tiru, eigvals, svdvals
@@ -186,6 +186,7 @@ include("float/arith.jl")
 include("float/arith_inplace.jl")
 include("float/morearith.jl")
 include("float/muladd.jl")
+include("float/dot.jl")
 include("float/elementary.jl")
 include("float/otherspecial.jl")
 include("float/bessel.jl")

--- a/src/ArbNumerics.jl
+++ b/src/ArbNumerics.jl
@@ -37,7 +37,7 @@ export ArbNumber,
 
        inf, posinf, neginf, nan,
        typemax, typemin, floatmax, floatmin,
-       magnitude,     # complex magnitude, `angle` gives phase 
+       magnitude,     # complex magnitude, `angle` gives phase
 
        signs, signbits,
        significand_bits, relerror_bits, relaccuracy_bits,
@@ -62,7 +62,7 @@ export ArbNumber,
        regular_hypergeometric_0F1, regular_hypergeometric_1F1, regular_hypergeometric_2F1,
        F₀₁,  F₁₁, F₂₁, regularF₀₁,  regularF₁₁, regularF₂₁,
        elliptic_k, elliptic_e, elliptic_pi, elliptic_f,
-       elliptic_k2, elliptic_e2, elliptic_pi2, elliptic_f2, # modulus^2 
+       elliptic_k2, elliptic_e2, elliptic_pi2, elliptic_f2, # modulus^2
        elliptic_rf, elliptic_rg, elliptic_rj,
        weierstrass_p, weierstrass_invp, weierstrass_zeta, weierstrass_sigma,
        zeta, eta, xi,                  # Reimann
@@ -154,6 +154,8 @@ include("libarb/ArbFloat.jl")
 include("libarb/ArbReal.jl")
 include("libarb/ArbComplex.jl")
 include("support/complex.jl")
+
+include("support/ArblibVector.jl")
 
 include("support/random.jl")
 

--- a/src/float/dot.jl
+++ b/src/float/dot.jl
@@ -1,0 +1,31 @@
+for (TT,dot_f) in [(:ArbReal, @libarb(arb_dot)),(:ArbComplex, @libarb(acb_dot))]
+    @eval begin
+        function LinearAlgebra.dot(x::ArblibVector{T}, y::ArblibVector{T}) where {T<:$TT}
+            @assert x.len == y.len
+            res = T(0) # Aliasing is allowed between res and s
+
+            P = precision(T)
+
+            ccall($dot_f, Cvoid, (Ref{T}, Ref{T}, Clong,
+                                  Ref{T}, Clong,
+                                  Ref{T}, Clong,
+                                  Clong, Clong),
+                  res, res, 0, x.ptr, 0, y.ptr, 0, x.len, P)
+
+            res
+        end
+    end
+end
+
+function LinearAlgebra.dot(x::AbstractVector{T}, y::AbstractVector{T}) where {T<:ArbNumber}
+    length(x) == length(y) || throw(DimensionMismatch("x and y must have the same lengths"))
+    xv = ArblibVector(x)
+    yv = ArblibVector(y)
+
+    d = dot(xv, yv)
+
+    free!(xv)
+    free!(yv)
+
+    T(d)
+end

--- a/src/libarb/ArbFFT.jl
+++ b/src/libarb/ArbFFT.jl
@@ -1,12 +1,12 @@
-for (f,acb_f) in [(:dft, @libarb(:acb_dft), (:inverse_dft, :acb_dft_inverse))]
+for (f,acb_f) in [(:dft, :acb_dft), (:inverse_dft, :acb_dft_inverse)]
     @eval begin
         function $f(x::Vector{ArbComplex{P}}) where P
             n = length(x)
-            x_c = AcbVector(x)
-            transf_c = AcbVector(ArbComplex{P}, n)
+            x_c = ArblibVector(x)
+            transf_c = ArblibVector(ArbComplex{P}, n)
 
             # Signature: void acb_dft(acb_ptr w, acb_srcptr v, slong n, slong prec)
-            ccall($acb_f, Cvoid, (Ref{ArbComplex{P}}, Ref{ArbComplex{P}}, Cint, Cint ), transf_c.ptr, x_c.ptr, n, P)
+            ccall(@libarb($acb_f), Cvoid, (Ref{ArbComplex{P}}, Ref{ArbComplex{P}}, Cint, Cint ), transf_c.ptr, x_c.ptr, n, P)
 
             free!(x_c)
 

--- a/src/libarb/ArbFFT.jl
+++ b/src/libarb/ArbFFT.jl
@@ -1,41 +1,19 @@
-function dft(x::Array{ArbComplex{P},1}) where {P}
-    # to guarantee safe bounds
-    length = size(x)[1]
-    
-    # we transfer the data into a C acb vector
-    
-    #(ALLOC x_c) Allocate the memory in C space
-    x_c = ccall(@libarb(_acb_vec_init), Ptr{ArbComplex{P}}, (Int32,), length)
-    #
-    
-    # copy x_c
-    @inbounds for i in 1:length
-                unsafe_store!(x_c, x[i], i)
-              end
-    #
-    
-    #(ALLOC transf_C)
-    transf_c = ccall(@libarb(_acb_vec_init), Ptr{ArbComplex{P}}, (Int32,), length)
-    #
-    
-    # we call the acb_dft 
-    # Signature: void acb_dft(acb_ptr w, acb_srcptr v, slong n, slong prec)
-    ccall(@libarb(acb_dft), Cvoid, (Ref{ArbComplex{P}}, Ref{ArbComplex{P}}, Cint, Cint ), transf_c, x_c, length, P)
-    
-    #(DEALLOC x_c)
-    ccall(@libarb(_acb_vec_clear), Cvoid, (Ref{ArbComplex{P}}, Cint ), x_c, length)
-    #
-    
-    transf = zeros(ArbComplex{P}, length)
-    @inbounds for i in 1:length
-                transf[i] = unsafe_load(transf_c, i)
-              end
-    
-    #(DEALLOC transf_c)
-    ccall(@libarb(_acb_vec_clear), Cvoid, (Ref{ArbComplex{P}}, Cint ), transf_c, length)
-    #
-    
-    return transf
+for (f,acb_f) in [(:dft, @libarb(:acb_dft), (:inverse_dft, :acb_dft_inverse))]
+    @eval begin
+        function $f(x::Vector{ArbComplex{P}}) where P
+            n = length(x)
+            x_c = AcbVector(x)
+            transf_c = AcbVector(ArbComplex{P}, n)
+
+            # Signature: void acb_dft(acb_ptr w, acb_srcptr v, slong n, slong prec)
+            ccall($acb_f, Cvoid, (Ref{ArbComplex{P}}, Ref{ArbComplex{P}}, Cint, Cint ), transf_c.ptr, x_c.ptr, n, P)
+
+            free!(x_c)
+
+            # Copy data and release memory
+            take!(transf_c)
+        end
+    end
 end
 
 dft(x::Array{ArbComplex,1}) = dft(Array{ArbComplex{workingprecision(ArbComplex)}, 1}(x))
@@ -43,46 +21,6 @@ dft(x::Array{ArbReal{P},1}) where {P} = dft(Array{ArbComplex{P}, 1}(x))
 dft(x::Array{ArbFloat{P},1}) where {P} = dft(Array{ArbComplex{P}, 1}(x))
 dft(x::Array{ArbReal,1}) = dft(Array{ArbComplex{workingprecision(ArbReal)}, 1}(x))
 dft(x::Array{ArbFloat,1}) = dft(Array{ArbComplex{workingprecision(ArbFloat)}, 1}(x))
-
-function inverse_dft(x::Array{ArbComplex{P},1}) where {P}
-    # to guarantee safe bounds
-    length = size(x)[1]
-    
-    # we transfer the data into a C acb vector
-    
-    #(ALLOC x_c) Allocate the memory in C space
-    x_c = ccall(@libarb(_acb_vec_init), Ptr{ArbComplex{P}}, (Int32,), length)
-    #
-    
-    # copy x_c
-    @inbounds for i in 1:length
-                unsafe_store!(x_c, x[i], i)
-              end
-    #
-    
-    #(ALLOC transf_C)
-    transf_c = ccall(@libarb(_acb_vec_init), Ptr{ArbComplex{P}}, (Int32,), length)
-    #
-    
-    # we call the acb_dft 
-    # Signature: void acb_dft(acb_ptr w, acb_srcptr v, slong n, slong prec)
-    ccall(@libarb(acb_dft_inverse), Cvoid, (Ref{ArbComplex{P}}, Ref{ArbComplex{P}}, Cint, Cint ), transf_c, x_c, length, P)
-    
-    #(DEALLOC x_c)
-    ccall(@libarb(_acb_vec_clear), Cvoid, (Ref{ArbComplex{P}}, Cint ), x_c, length)
-    #
-    
-    transf = zeros(ArbComplex{P}, length)
-    @inbounds for i in 1:length
-                transf[i] = unsafe_load(transf_c, i)
-              end
-    
-    #(DEALLOC transf_c)
-    ccall(@libarb(_acb_vec_clear), Cvoid, (Ref{ArbComplex{P}}, Cint ), transf_c, length)
-    #
-    
-    return transf
-end
 
 inverse_dft(x::Array{ArbComplex,1}) = inverse_dft(Array{ArbComplex{workingprecision(ArbComplex)}, 1}(x))
 inverse_dft(x::Array{ArbReal{P},1}) where {P} = dft(Array{ArbComplex{P}, 1}(x))

--- a/src/support/ArblibVector.jl
+++ b/src/support/ArblibVector.jl
@@ -1,0 +1,94 @@
+for (TT,init_f,clear_f) in [(:ArbReal,@libarb(_arb_vec_init),@libarb(_arb_vec_clear)),
+                            (:ArbComplex,@libarb(_acb_vec_init),@libarb(_acb_vec_clear))]
+    @eval begin
+        init(::Type{T}, len::Integer) where {T<:$TT} =
+            ccall($init_f, Ptr{T}, (Int32,), len)
+
+        clear!(ptr::Ptr{T}, len::Integer) where {T<:$TT} =
+            ccall($clear_f, Cvoid, (Ref{T}, Cint), ptr, len)
+    end
+end
+
+"""
+    ArblibVector{T}(ptr, len)
+
+Vector of length `len` containing elements of type `T` with memory
+handled by libarb.
+"""
+mutable struct ArblibVector{T} <: AbstractVector{T}
+    ptr::Ptr{T}
+    len::Int32
+
+    """
+    ArblibVector(::Type{T}, len)
+
+Allocate uninitialized vector of length `len` containing elements of type `T`.
+"""
+    ArblibVector(::Type{T}, len::Int) where T = new{T}(init(T, len), len)
+end
+
+const ArbVector{P} = ArblibVector{ArbReal{P}}
+const AcbVector{P} = ArblibVector{ArbComplex{P}}
+
+Base.eltype(v::ArblibVector{T}) where T = T
+Base.length(v::ArblibVector) = v.len
+Base.size(v::ArblibVector) = (v.len,)
+
+function Base.getindex(v::ArblibVector{T}, i::Integer) where T
+    i ∈ 1:v.len || throw(BoundsError(v, i))
+    unsafe_load(v.ptr, i)
+end
+
+"""
+    ArblibVector(v::AbstractVector{T})
+
+Construct `ArblibVector` and fill with data from `v`.
+"""
+function ArblibVector(v::AbstractVector{T}) where T
+    vv = ArblibVector(T, length(v))
+    @inbounds for (i,e) in enumerate(v)
+        unsafe_store!(vv.ptr, e, i)
+    end
+    vv
+end
+
+# ArblibVectors of ArbFloats are stored as ArbReals, since there is no
+# arf_ptr available.
+ArblibVector(v::AbstractVector{ArbFloat{P}}) where P =
+    ArblibVector(ArbReal.(v))
+
+"""
+    Vector(v::ArblibVector{T})
+
+Construct new `Vector` with elements copied from `v`.
+"""
+function Base.Vector(v::ArblibVector{T}) where T
+    vv = Vector{T}(undef, v.len)
+    @inbounds for i = 1:v.len
+        vv[i] = unsafe_load(v.ptr, i)
+    end
+    vv
+end
+
+"""
+    free!(v::ArblibVector{T})
+
+Free the memory allocated for `v` and null the pointer and length to
+prevent future accesses to released memory.
+"""
+function free!(v::ArblibVector{T}) where T
+    clear!(v.ptr, v.len)
+    v.ptr = C_NULL
+    v.len = 0
+end
+
+"""
+    take!(v::ArblibVector)
+
+Copy the data of `v` to a [`Vector`](@ref) and release the memory.
+"""
+function Base.take!(v::ArblibVector)
+    vv = Vector(v)
+    free!(v)
+    vv
+end

--- a/test/ArblibVector.jl
+++ b/test/ArblibVector.jl
@@ -1,0 +1,38 @@
+import ArbNumerics: ArblibVector, take!, free!
+
+@testset "ArblibVectors" begin
+    @testset "ArblibVector{$T}" for T = [ArbReal{128},ArbComplex{128}]
+        v = rand(T, 5)
+        vv = ArblibVector(v)
+
+        @test eltype(vv) == T
+        @test length(vv) == 5
+        @test size(vv) == (5,)
+
+        @test vv[1] == v[1]
+        @test_throws BoundsError vv[0]
+        @test_throws BoundsError vv[6]
+
+        vvv = take!(vv)
+        @test vvv == v
+
+        @test length(vv) == 0
+        @test vv.ptr == C_NULL
+        @test_throws BoundsError vv[1]
+    end
+
+    @testset "ArbFloat" begin
+        v = rand(ArbFloat{128}, 5)
+        vv = ArblibVector(v)
+
+        @test eltype(vv) == ArbReal{128}
+
+        vvv = Vector{ArbFloat{128}}(vv)
+        free!(vv)
+        @test length(vv) == 0
+        @test vv.ptr == C_NULL
+
+        @test vvv == v
+        @test eltype(vvv) == ArbFloat{128}
+    end
+end

--- a/test/ArblibVector.jl
+++ b/test/ArblibVector.jl
@@ -1,4 +1,5 @@
 import ArbNumerics: ArblibVector, take!, free!
+using LinearAlgebra
 
 @testset "ArblibVectors" begin
     @testset "ArblibVector{$T}" for T = [ArbReal{128},ArbComplex{128}]
@@ -19,6 +20,21 @@ import ArbNumerics: ArblibVector, take!, free!
         @test length(vv) == 0
         @test vv.ptr == C_NULL
         @test_throws BoundsError vv[1]
+
+        @testset "Dot product" begin
+            # Test automatic copy to ArblibVector and dot product
+            o = ones(T, 5)
+            d = dot(o,o)
+            @test d isa T
+            @test d == T(5)
+
+            # Test dot product on manually allocated ArblibVector
+            O = ArblibVector(o)
+            D = dot(O,O)
+            @test D isa T
+            @test D == T(5)
+            free!(O)
+        end
     end
 
     @testset "ArbFloat" begin
@@ -34,5 +50,12 @@ import ArbNumerics: ArblibVector, take!, free!
 
         @test vvv == v
         @test eltype(vvv) == ArbFloat{128}
+
+        @testset "Dot product" begin
+            o = ones(ArbFloat{128}, 5)
+            d = dot(o,o)
+            @test d isa ArbFloat{128}
+            @test d == ArbFloat{128}(5)
+        end
     end
 end

--- a/test/dft.jl
+++ b/test/dft.jl
@@ -1,0 +1,11 @@
+@testset "DFT" begin
+    x = ArbComplex.(1.0:4)
+    y = [ArbComplex(10.0), ArbComplex(-2.0,+2.0), ArbComplex(-2.0),ArbComplex(-2.0,-2.0)]
+    @test dft(x) == y
+    @test inverse_dft(y) == x
+
+    u = vcat(one(ArbComplex), zeros(ArbComplex, 7))
+    v = ones(ArbComplex, 8)
+    @test dft(u) == v
+    @test dft(im*u) == im*v
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,4 +14,5 @@ end
   include("elementaryfunctions.jl")
   include("misc.jl")
   include("complex.jl")
+  include("dft.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using Test
 
 setprecision(BigFloat, 512)
 
+@testset "Support" begin
+    include("ArblibVector.jl")
+end
+
 @testset "ArbNumerics tests" begin
   include("specialvalues.jl")
   include("compare.jl")


### PR DESCRIPTION
This helper struct simplifies calls to Arb functions that expect vector inputs. There were no tests for the DFT routines, so I am not sure if they have been broken or not, but they should not be.