### PR TITLE
Implement Struve Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,8 @@ Consider using ArbReals instead of ArbFloats if you want your results to be rock
 - `weierstrass_zeta`, `weierstrass_sigma`
 
 #### hypergeometric functions
-    
-- `hypgeom0f1`, `hypgeom1f1`, `hypgeom1f2`  
-- `hypgeom0f1reg`, `hypgeom1f1reg`, `hypgeom1f2reg` (regularized)
+- `hypergeometric_0F1`, `hypergeometric_1F1`, `hypergeometric_2F1`, `hypergeometric_1F2`
+- `regular_hypergeometric_0F1`, `regular_hypergeometric_1F1`, `regular_hypergeometric_2F1`, `regular_hypergeometric_1F2` (regularized)
    
 #### other special functions
 
@@ -228,6 +227,7 @@ Consider using ArbReals instead of ArbFloats if you want your results to be rock
 - `shi`, `chi`
 - `zeta`, `eta`, `xi`    # Reimann
 - `lambertw`, `polylog`
+- `struve`
 
 #### linear algebra
 

--- a/src/ArbNumerics.jl
+++ b/src/ArbNumerics.jl
@@ -69,6 +69,7 @@ export ArbNumber,
        zeta, eta, xi,                  # Reimann
        lambertw, polylog,
        π, ℯ, γ, φ, catalan,
+       struve,
 
        # fft
        dft, inverse_dft,

--- a/src/ArbNumerics.jl
+++ b/src/ArbNumerics.jl
@@ -59,9 +59,9 @@ export ArbNumber,
        ei, si, ci, shi, chi,
        airyai, airyaiprime, airybi, airybiprime,
        besselj, besselj0, besselj1, bessely, bessely0, bessely1, besseli, besselk,
-       hypergeometric_0F1, hypergeometric_1F1, hypergeometric_2F1,
-       regular_hypergeometric_0F1, regular_hypergeometric_1F1, regular_hypergeometric_2F1,
-       F₀₁,  F₁₁, F₂₁, regularF₀₁,  regularF₁₁, regularF₂₁,
+       hypergeometric_0F1, hypergeometric_1F1, hypergeometric_2F1, hypergeometric_1F2,
+       regular_hypergeometric_0F1, regular_hypergeometric_1F1, regular_hypergeometric_2F1, regular_hypergeometric_1F2,
+       F₀₁,  F₁₁, F₂₁, F₁₂, regularF₀₁,  regularF₁₁, regularF₂₁, regularF₁₂,
        elliptic_k, elliptic_e, elliptic_pi, elliptic_f,
        elliptic_k2, elliptic_e2, elliptic_pi2, elliptic_f2, # modulus^2
        elliptic_rf, elliptic_rg, elliptic_rj,
@@ -127,9 +127,9 @@ import SpecialFunctions: gamma, lgamma, lfact, digamma, invdigamma, polygamma, t
      besselj, besselj0, besselj1, bessely, bessely0, bessely1, besseli, besselk,
      eta, zeta
 
-using  GenericSVD
+using GenericSVD
 
-using  LinearAlgebra
+using LinearAlgebra
 import LinearAlgebra: tr, det, transpose, transpose!, norm, lu, ldlt,
                       cholesky, tril, triu, eigvals, svdvals, floatmin2,
                       mul!, rmul!, lmul!, eigvecs, svd, eigen, dot
@@ -163,7 +163,7 @@ include("support/ArblibVector.jl")
 
 include("support/random.jl")
 
-const ArbNumber = Union{ArbFloat, ArbReal, ArbComplex}
+const ArbNumber = Union{ArbFloat,ArbReal,ArbComplex}
 
 include("libarb/ArbMatrix.jl")  # must preceed ArbRealMatrix
 include("libarb/ArbRealMatrix.jl")  # must preceed ArbFloatMatrix

--- a/src/float/hypergeometric.jl
+++ b/src/float/hypergeometric.jl
@@ -1,4 +1,4 @@
-#=
+#= 
 void acb_hypgeom_u(acb_t res, const acb_t a, const acb_t b, const acb_t z, slong prec)¶
 Computes U(a,b,z) using an automatic algorithm choice.
 
@@ -10,7 +10,9 @@ Computes the confluent hypergeometric function M(a,b,z)=1F1(a,b,z), or M(a,b,z)=
 
 acb_hypgeom_2f1(acb_t res, const acb_t a, const acb_t b,
         const acb_t c, const acb_t z, int flags, slong prec)
-=#
+
+void acb_hypgeom_pfq(acb_poly_t res, acb_srcptr a, slong p, acb_srcptr b, slong q, const acb_t z, int regularized, slong prec)
+Computes the generalized hypergeometric function pFq(z), or the regularized version if regularized is set. =#
 
 """
     hypergeometric_0F1(a, z)
@@ -114,6 +116,40 @@ end
 
 const regularF₂₁ = regular_hypergeometric_2F1
 
+"""
+    hypergeometric_1F2(a, b, z)
+
+generalized hypergeometric function ``₁F₂``
+"""
+function hypergeometric_1F2(a::ArbComplex{P}, b::ArbComplex{P}, z::ArbComplex{P}) where {P}
+    result = ArbComplex{P}()
+    regularized = Cint(0)
+    p = Clong(1)
+    q = Clong(2)
+    ccall(@libarb(acb_hypgeom_pfq), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Clong, Ref{ArbComplex}, Clong, Ref{ArbComplex}, Cint, Clong),
+         result, a, p, b, q, z, regularized, P)
+    return result
+end
+
+const F₁₂ = hypergeometric_1F2
+
+"""
+regular_hypergeometric_1F2(a, b, z)
+
+regularized generalized hypergeometric function ``₁F₂ / gamma(a)``
+"""
+function regular_hypergeometric_1F2(a::ArbComplex{P}, b::ArbComplex{P}, z::ArbComplex{P}) where {P}
+    result = ArbComplex{P}()
+    regularized = Cint(1)
+    p = Clong(1)
+    q = Clong(2)
+    ccall(@libarb(acb_hypgeom_pfq), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Clong, Ref{ArbComplex}, Clong, Ref{ArbComplex}, Cint, Clong),
+         result, a, p, b, q, z, regularized, P)
+    return result
+end
+
+const regularF₁₂ = regular_hypergeometric_1F2
+
 function hypergeometric_0F1(a::ArbReal{P}, z::ArbReal{P}) where {P}
     result = ArbReal{P}()
     regularized = Cint(0)
@@ -169,7 +205,25 @@ function regular_hypergeometric_2F1(a::ArbReal{P}, b::ArbReal{P}, c::ArbReal{P},
     return result
 end
 
-# ArbFloat
+function hypergeometric_1F2(a::ArbReal{P}, b::ArbReal{P}, z::ArbReal{P}) where {P}
+    result = ArbReal{P}()
+    regularized = Cint(0)
+    p = Clong(1)
+    q = Clong(2)
+    ccall(@libarb(arb_hypgeom_pfq), Cvoid, (Ref{ArbReal}, Ref{ArbReal}, Clong, Ref{ArbReal}, Clong, Ref{ArbReal}, Cint, Clong),
+         result, a, p, b, q, z, regularized, P)
+    return result
+end
+
+function regular_hypergeometric_1F2(a::ArbReal{P}, b::ArbReal{P}, z::ArbReal{P}) where {P}
+    result = ArbReal{P}()
+    regularized = Cint(1)
+    p = Clong(1)
+    q = Clong(2)
+    ccall(@libarb(arb_hypgeom_pfq), Cvoid, (Ref{ArbReal}, Ref{ArbReal}, Clong, Ref{ArbReal}, Clong, Ref{ArbReal}, Cint, Clong),
+         result, a, p, b, q, z, regularized, P)
+    return result
+end
 
 hypergeometric_0F1(a::ArbFloat{P}, z::ArbFloat{P}) where {P} =
     ArbFloat{P}(hypgeom0f1(ArbReal{P}(a), ArbReal{P}(z)))

--- a/src/float/otherspecial.jl
+++ b/src/float/otherspecial.jl
@@ -293,3 +293,13 @@ function erfcx(x::ArbFloat{P}; magnify=2.125) where {P}
     res = erfcx(ArbReal(x); magnify=magnify)
     return ArbFloat(res)
 end
+
+"""
+    struve(α, z)
+
+The Struve Functions, Hₐ(z), calculated from the generalized hypergeometric function, ₁F₂
+"""
+function struve(α::ArbComplex{P}, z::ArbComplex{P}) where {P}
+    return z^(α + 1) / (2^α * sqrt(ArbReal(pi) * gamma(α + 3/2))) *
+        hypergeometric_1F2(ArbComplex(1), α + 3/2, -z^2 / 4)
+end


### PR DESCRIPTION
The [Struve functions](https://en.wikipedia.org/wiki/Struve_function) are special functions that are useful in physics. There is no arbitrary precision implementation for these in Julia. This PR implements them in in this package.

The Struve functions are not directly implemented in the Arb C Library and can be [expressed in terms of the 1F2 hypergeometric function](https://en.wikipedia.org/wiki/Struve_function#Relation_to_other_functions). The README for this package claims to have a `hypgeom1f2` function, but it instead has an implementation of the 2F1 hypergeometric function called `hypergeometric_2F1`. This PR adds a wrapper for the 1F2 hypergeometric function and corrects the mistake in the README.

TODO:
- [ ] The 1F2 wrapper currently does not appear to work. There is a segmentation fault when calling the C library. I suspect this is because the types required for the `acb_hypgeom_pfq` function are slightly different from the rest of the wrapped hypergeometric functions (`acb_poly_t` instead of `acb_t` and `acb_srcptr ` instead of `const acb_t`). Any suggestions?

@mdavezac