### PR TITLE
Added missing Weierstrass functions, fixed type on acb_abs

### DIFF
--- a/src/ArbNumerics.jl
+++ b/src/ArbNumerics.jl
@@ -65,7 +65,7 @@ export ArbNumber,
        elliptic_k, elliptic_e, elliptic_pi, elliptic_f,
        elliptic_k2, elliptic_e2, elliptic_pi2, elliptic_f2, # modulus^2
        elliptic_rf, elliptic_rg, elliptic_rj,
-       weierstrass_p, weierstrass_invp, weierstrass_zeta, weierstrass_sigma,
+       weierstrass_p, weierstrass_p_prime, weierstrass_p_jet, weierstrass_invariants, weierstrass_roots, weierstrass_p_series, weierstrass_inv_p, weierstrass_zeta, weierstrass_sigma,
        zeta, eta, xi,                  # Reimann
        lambertw, polylog,
        π, ℯ, γ, φ, catalan,
@@ -196,6 +196,7 @@ include("float/otherspecial.jl")
 include("float/bessel.jl")
 include("float/airy.jl")
 include("float/elliptic.jl")
+include("float/weierstrass.jl")
 include("float/hypergeometric.jl")
 include("float/export_fallbacks.jl")
 

--- a/src/float/prearith.jl
+++ b/src/float/prearith.jl
@@ -82,7 +82,7 @@ function abs(x::ArbReal{P}) where {P}
 end
 
 function abs(x::ArbComplex{P}) where {P}
-    z = ArbComplex{P}()
+    z = ArbReal{P}()
     ccall(@libarb(acb_abs), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Clong), z, x, P)
     return z
 end

--- a/src/float/weierstrass.jl
+++ b/src/float/weierstrass.jl
@@ -26,11 +26,70 @@ function weierstrass_p(z::ArbComplex{P}, tau::ArbComplex{P}) where {P}
 end
 
 """
+    weierstrass_p_prime(z, tau)
+
+- weierstrass_p_prime(z, tau) == derivative of weierstrass_p(z, tau)
+"""
+function weierstrass_p_prime(z::ArbComplex{P}, tau::ArbComplex{P}) where {P}
+    result = ArbComplex{P}()
+    flag = 0
+    ccall(@libarb(acb_elliptic_p_prime), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), 
+          result, z, tau, P)
+    return result
+end
+
+"""
+    weierstrass_p_jet(z, tau)
+
+- weierstrass_p_jet(z, tau, len=2) == first len derivatives of weierstrass_p(z, tau)
+"""
+function weierstrass_p_jet(z::ArbComplex{P}, tau::ArbComplex{P}, len::Int = 2) where {P}
+    result = ArblibVector(ArbComplex{P},len)
+    flag = 0
+    ccall(@libarb(acb_elliptic_p_jet), Cvoid, (Ptr{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint, Cint), 
+          result.ptr, z, tau, len, P)
+    return result
+end
+
+"""
+void acb_elliptic_p_series(acb_poly_t res, const acb_poly_t z, const acb_t tau, slong len, slong prec)
+"""
+
+"""
+   weierstrass_invariants(tau)
+
+- (g2, g3) the invariants such that (℘')^2 = 4℘^3 - g2*℘ - g3
+"""
+function weierstrass_invariants(tau::ArbComplex{P}) where {P}
+    g2 = ArbComplex{P}()
+    g3 = ArbComplex{P}()
+    flag = 0
+    ccall(@libarb(acb_elliptic_invariants), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), 
+          g2, g3, tau, P)
+    return (g2, g3)
+end
+
+"""
+  weierstrass_roots(tau)
+
+- (e1,e2,e3) the roots of 4z^3 - g2*z - g3
+"""
+function weierstrass_roots(tau::ArbComplex{P}) where {P}
+    e1 = ArbComplex{P}()
+    e2 = ArbComplex{P}()
+    e3 = ArbComplex{P}()
+    flag = 0
+    ccall(@libarb(acb_elliptic_roots), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), 
+          e1, e2, e3, tau, P)
+    return (e1, e2, e3)
+end
+
+"""
     weierstrass_invp(z, tau)
 
 - weierstrass_p(weierstrass_invp(z, tau), tau) == z
 """
-function weierstrass_invp(z::ArbComplex{P}, tau::ArbComplex{P}) where {P}
+function weierstrass_inv_p(z::ArbComplex{P}, tau::ArbComplex{P}) where {P}
     result = ArbComplex{P}()
     flag = 0
     ccall(@libarb(acb_elliptic_inv_p), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), 
@@ -66,22 +125,43 @@ function weierstrass_sigma(z::ArbComplex{P}, tau::ArbComplex{P}) where {P}
 end
 
 
-weierstrass_p(z::ArbReal{P}, tau::ArbReal{P}) where {P} =
+weierstrass_p(z::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}, tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}) where {P} =
     weierstrass_p(ArbComplex{P}(z), ArbComplex{P}(tau))
-weierstrass_p(z::ArbFloat{P}, tau::ArbFloat{P}) where {P} =
-    weierstrass_p(ArbComplex{P}(z), ArbComplex{P}(tau))
+weierstrass_p(z, tau1, tau2) = weierstrass_p(z/tau1, tau2/tau1)/tau1^2
 
-weierstrass_pinv(z::ArbReal{P}, tau::ArbReal{P}) where {P} =
-    weierstrass_pinv(ArbComplex{P}(z), ArbComplex{P}(tau))
-weierstrass_pinv(z::ArbFloat{P}, tau::ArbFloat{P}) where {P} =
-    weierstrass_pinv(ArbComplex{P}(z), ArbComplex{P}(tau))
+weierstrass_p_prime(z::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}, tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}) where {P} =
+    weierstrass_p_prime(ArbComplex{P}(z), ArbComplex{P}(tau))
+weierstrass_p_prime(z, tau1, tau2) = weierstrass_p_prime(z/tau1, tau2/tau1)/tau1^3
+
+weierstrass_p_jet(z::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}, tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}, len::Int = 2) where {P} =
+    weierstrass_p_jet(ArbComplex{P}(z), ArbComplex{P}(tau), len)
+function weierstrass_p_jet(z, tau1, tau2, len::Int = 2)
+    tauinv = 1/tau1
+    jet = weierstrass_p_jet(z*tauinv, tau2*tauinv, len)
+    scale = tauinv
+    for i=1:len
+        scale *= tauinv
+        unsafe_store!(jet.ptr, jet[i]*scale, i) # ArbVector has no store method
+    end
+    jet
+end
+                                                  
+weierstrass_invariants(tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}) where {P} =
+    weierstrass_invariants(ArbComplex{P}(tau))
+weierstrass_invariants(tau1, tau2) = (i = weierstrass_invariants(tau2/tau1); (i[1]/tau1^4, i[2]/tau1^6))
     
-weierstrass_zeta(z::ArbReal{P}, tau::ArbReal{P}) where {P} =
+weierstrass_roots(tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}) where {P} =
+    weierstrass_roots(ArbComplex{P}(tau))
+weierstrass_roots(tau1, tau2) = weierstrass_roots(tau2/tau1)./tau1^2
+
+weierstrass_inv_p(z::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}, tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}) where {P} =
+    weierstrass_inv_p(ArbComplex{P}(z), ArbComplex{P}(tau))
+weierstrass_inv_p(z, tau1, tau2) = weierstrass_inv_p(z*tau1^2, tau2/tau1)*tau1
+
+weierstrass_zeta(z::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}, tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}) where {P} =
     weierstrass_zeta(ArbComplex{P}(z), ArbComplex{P}(tau))
-weierstrass_zeta(z::ArbFloat{P}, tau::ArbFloat{P}) where {P} =
-    weierstrass_zeta(ArbComplex{P}(z), ArbComplex{P}(tau))
-    
-weierstrass_sigma(z::ArbReal{P}, tau::ArbReal{P}) where {P} =
+weierstrass_zeta(z, tau1, tau2) = weierstrass_zeta(z/tau1, tau2/tau1)/tau1
+
+weierstrass_sigma(z::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}, tau::Union{ArbReal{P},ArbFloat{P},ArbComplex{P}}) where {P} =
     weierstrass_sigma(ArbComplex{P}(z), ArbComplex{P}(tau))
-weierstrass_sigma(z::ArbFloat{P}, tau::ArbFloat{P}) where {P} =
-    weierstrass_sigma(ArbComplex{P}(z), ArbComplex{P}(tau))
+weierstrass_sigma(z, tau1, tau2) = weierstrass_sigma(z/tau1, tau2/tau1)*tau1

--- a/test/elementaryfunctions.jl
+++ b/test/elementaryfunctions.jl
@@ -72,3 +72,19 @@ end
    @test isapprox(asech(flb), asech(arb))
    @test isapprox(acoth(fla), acoth(ara))
 end
+
+@testset "Weierstrass elliptic functions" begin
+    τ = ArbComplex(1.0im)
+    @test isapprox(weierstrass_p(ArbComplex(0.5+0.5im),τ),0.0,atol=1.e-8)
+    z = weierstrass_p_jet(ArbComplex(0.5),τ)
+    @test isapprox(z[1],6.87518581802)
+    @test isapprox(z[2],0.0,atol=1.e-8)
+    @test isapprox(weierstrass_inv_p(z[1],τ),0.5)
+    inv = weierstrass_invariants(τ)
+    @test isapprox(inv[1],189.0727201292338)
+    @test isapprox(inv[2],0.0,atol=1.e-8)
+    rt = weierstrass_roots(τ)
+    @test isapprox(rt[1],6.87518581802037282)
+    @test isapprox(rt[2],0.0,atol=1.e-8)
+    @test isapprox(rt[3],-6.87518581802037282)
+end


### PR DESCRIPTION
This PR exposes functions from the library: weierstrass_p_jet, weierstrass_invariants, weierstrass_roots etc.

It also fixes the return type of acb_abs, which should be an arb and not an acb.

Note that weierstrass_p_prime is in the 2.22 version of the library, but not in the one currently shipped with Julia, so its use returns an error "missing symbol". A temporary workaround is using weiertrass_p_jet(args...)[2]; but it would be best to upgrade the C library.