### PR TITLE
Add polygamma function

### DIFF
--- a/src/ArbNumerics.jl
+++ b/src/ArbNumerics.jl
@@ -67,7 +67,7 @@ export ArbNumber,
        elliptic_rf, elliptic_rg, elliptic_rj,
        weierstrass_p, weierstrass_p_prime, weierstrass_p_jet, weierstrass_invariants, weierstrass_roots, weierstrass_p_series, weierstrass_inv_p, weierstrass_zeta, weierstrass_sigma,
        zeta, eta, xi,                  # Reimann
-       lambertw, polylog,
+       lambertw, polylog, polygamma,
        π, ℯ, γ, φ, catalan,
 
        # fft

--- a/src/float/otherspecial.jl
+++ b/src/float/otherspecial.jl
@@ -216,6 +216,26 @@ function polylog(s::Int, z::ArbFloat{P}, prec::Int=P) where {P}
     return wc
 end
 
+function polygamma(s::ArbComplex{P}, z::ArbComplex{P}, prec::Int=P) where {P}
+    res = ArbComplex{P}()
+    ccall(@libarb(acb_polygamma), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), res, s, z, prec)
+    return res
+end
+
+function polygamma(s::ArbReal{P}, z::ArbReal{P}, prec::Int=P) where {P}
+    sc = ArbComplex(s)
+    zc = ArbComplex(z)
+    wc = polygamma(sc, zc, prec)
+    return wc
+end
+
+function polygamma(s::ArbFloat{P}, z::ArbFloat{P}, prec::Int=P) where {P}
+    sc = ArbComplex(s)
+    zc = ArbComplex(z)
+    wc = polygamma(sc, zc, prec)
+    return wc
+end
+
 
 #=
 function erfcx(z::ArbComplex{P}) where {P}

--- a/src/float/otherspecial.jl
+++ b/src/float/otherspecial.jl
@@ -86,43 +86,6 @@ for (A,F) in ((:agm, :arb_agm), )
     end
 end
 
-function polylog(s::ArbComplex{P}, z::ArbComplex{P}, prec::Int=P) where {P}
-    w = ArbComplex{P}()
-    ccall(@libarb(acb_polylog), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), w, s, z, prec)
-    return w
-end
-
-function polylog(s::ArbReal{P}, z::ArbReal{P}, prec::Int=P) where {P}
-    sc = ArbComplex(s)
-    zc = ArbComplex(z)
-    wc = polylog(sc, zc, prec)
-    return wc
-end
-
-function polylog(s::ArbFloat{P}, z::ArbFloat{P}, prec::Int=P) where {P}
-    sc = ArbComplex(s)
-    zc = ArbComplex(z)
-    wc = polylog(sc, zc, prec)
-    return wc
-end
-
-function polylog(s::Int, z::ArbComplex{P}, prec::Int=P) where {P}
-    w = ArbComplex{P}()
-    ccall(@libarb(acb_polylog_si), Cvoid, (Ref{ArbComplex}, Cint, Ref{ArbComplex}, Cint), w, s, z, prec)
-    return w
-end
-
-function polylog(s::Int, z::ArbReal{P}, prec::Int=P) where {P}
-    zc = ArbComplex(z)
-    wc = polylog(s, zc, prec)
-    return wc
-end
-
-function polylog(s::Int, z::ArbFloat{P}, prec::Int=P) where {P}
-    zc = ArbComplex(z)
-    wc = polylog(s, zc, prec)
-    return wc
-end
 
 
 
@@ -212,6 +175,45 @@ function agm(x::ArbFloat{P}, y::ArbFloat{P}) where {P}
     w  = agm(x1, y1)
     z = midpoint_byref(w)
     return z
+end
+
+
+function polylog(s::ArbComplex{P}, z::ArbComplex{P}, prec::Int=P) where {P}
+    w = ArbComplex{P}()
+    ccall(@libarb(acb_polylog), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), w, s, z, prec)
+    return w
+end
+
+function polylog(s::ArbReal{P}, z::ArbReal{P}, prec::Int=P) where {P}
+    sc = ArbComplex(s)
+    zc = ArbComplex(z)
+    wc = polylog(sc, zc, prec)
+    return wc
+end
+
+function polylog(s::ArbFloat{P}, z::ArbFloat{P}, prec::Int=P) where {P}
+    sc = ArbComplex(s)
+    zc = ArbComplex(z)
+    wc = polylog(sc, zc, prec)
+    return wc
+end
+
+function polylog(s::Int, z::ArbComplex{P}, prec::Int=P) where {P}
+    w = ArbComplex{P}()
+    ccall(@libarb(acb_polylog_si), Cvoid, (Ref{ArbComplex}, Cint, Ref{ArbComplex}, Cint), w, s, z, prec)
+    return w
+end
+
+function polylog(s::Int, z::ArbReal{P}, prec::Int=P) where {P}
+    zc = ArbComplex(z)
+    wc = polylog(s, zc, prec)
+    return wc
+end
+
+function polylog(s::Int, z::ArbFloat{P}, prec::Int=P) where {P}
+    zc = ArbComplex(z)
+    wc = polylog(s, zc, prec)
+    return wc
 end
 
 

--- a/src/float/otherspecial.jl
+++ b/src/float/otherspecial.jl
@@ -225,15 +225,15 @@ end
 function polygamma(s::ArbReal{P}, z::ArbReal{P}, prec::Int=P) where {P}
     sc = ArbComplex(s)
     zc = ArbComplex(z)
-    wc = polygamma(sc, zc, prec)
-    return wc
+    res = polygamma(sc, zc, prec)
+    return res
 end
 
 function polygamma(s::ArbFloat{P}, z::ArbFloat{P}, prec::Int=P) where {P}
     sc = ArbComplex(s)
     zc = ArbComplex(z)
-    wc = polygamma(sc, zc, prec)
-    return wc
+    res = polygamma(sc, zc, prec)
+    return res
 end
 
 

--- a/src/float/otherspecial.jl
+++ b/src/float/otherspecial.jl
@@ -88,7 +88,7 @@ end
 
 function polylog(s::ArbComplex{P}, z::ArbComplex{P}, prec::Int=P) where {P}
     w = ArbComplex{P}()
-    ccall(@libarb(acb_polylog), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), w, s, z, P)
+    ccall(@libarb(acb_polylog), Cvoid, (Ref{ArbComplex}, Ref{ArbComplex}, Ref{ArbComplex}, Cint), w, s, z, prec)
     return w
 end
 
@@ -108,7 +108,7 @@ end
 
 function polylog(s::Int, z::ArbComplex{P}, prec::Int=P) where {P}
     w = ArbComplex{P}()
-    ccall(@libarb(acb_polylog_si), Cvoid, (Ref{ArbComplex}, Cint, Ref{ArbComplex}, Cint), w, s, z, P)
+    ccall(@libarb(acb_polylog_si), Cvoid, (Ref{ArbComplex}, Cint, Ref{ArbComplex}, Cint), w, s, z, prec)
     return w
 end
 
@@ -123,6 +123,8 @@ function polylog(s::Int, z::ArbFloat{P}, prec::Int=P) where {P}
     wc = polylog(s, zc, prec)
     return wc
 end
+
+
 
 #=
 for (A,F) in ((:ellipticp, :acb_elliptic_p), (:ellipticpi, :acb_elliptic_pi),


### PR DESCRIPTION
Hey,

Thanks for the great work with the library.

I fixed two small bugs in the polylog function (they weren't actually using the `prec` argument) and reordered the function definitions in the same file to be consistent (first all other specials with `ArbFloat` and `ArbComplex`, then polylog)

I also added support for the polygamma function since I needed it. Would be amazing if it could be merged into main. 