### PR TITLE
removed references to `Cint`in ArbComplex.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+*.jl.*.mem
+Manifest.toml
+settings.json
 deps/deps.jl

--- a/src/libarb/ArbComplex.jl
+++ b/src/libarb/ArbComplex.jl
@@ -102,8 +102,6 @@ end
 
 ArbComplex(re::T, im::T) where T<:AbstractFloat = ArbComplex(ArbFloat(re), ArbFloat(im))
 
-const Analytic = Cint(0) # prefer the non-analytic versions
-
 @inline sign_bit(x::ArbComplex{P}) where {P} = isodd(x.real_mid_size)
 @inline sign_bits(x::ArbComplex{P}) where {P} = isodd(x.real_mid_size), isodd(x.imag_mid_size)
 @inline sign_bit(x::ArbComplex{P}, ::Type{RealPart}) where {P} = isodd(x.real_mid_size)
@@ -116,9 +114,11 @@ function ArbComplex{P}(rea::Float64) where {P}
     return z
 end
 
-function ArbComplex{P}(rea::Cint) where {P}
+const ArbInts = Union{Int64,Int32,Int16,Int8}
+
+function ArbComplex{P}(rea::ArbInts) where {P}
     z = ArbComplex{P}()
-    ccall(@libarb(acb_set_si), Cvoid, (Ref{ArbComplex}, Cint), z, rea)
+    ccall(@libarb(acb_set_si), Cvoid, (Ref{ArbComplex}, Clong), z, rea)
     return z
 end
 
@@ -146,9 +146,9 @@ function ArbComplex{P}(re::Float64, im::Float64) where {P}
     return z
 end
 
-function ArbComplex{P}(x::Int64, y::Int64) where {P}
+function ArbComplex{P}(x::ArbInts, y::ArbInts) where {P}
     z = ArbComplex{P}()
-    ccall(@libarb(acb_set_si_si), Cvoid, (Ref{ArbComplex}, Cint, Cint, Clong), z, x, y, P)
+    ccall(@libarb(acb_set_si_si), Cvoid, (Ref{ArbComplex}, Clong, Clong, Clong), z, x, y, P)
     return z
 end
 
@@ -161,12 +161,11 @@ end
 
 deepcopy(x::ArbComplex{P}) where {P} = copy(x)
 
-
-function ArbComplex{P}(x::ArbComplex{Q}, roundingmode::RoundingMode) where {P,Q}
+# for backward compatibility (Arb does not support rounding modes)
+function ArbComplex{P}(x::ArbComplex{Q}, ::RoundingMode=RoundNearest) where {P,Q}
     z = ArbComplex{P}()
-    rounding = match_rounding_mode(roundingmode)
-    res = ccall(@libarb(acb_set_round), Cint,
-                (Ref{ArbComplex}, Ref{ArbComplex}, Clong, Cint), z, x, P, rounding)
+    res = ccall(@libarb(acb_set_round), Cvoid,
+                (Ref{ArbComplex}, Ref{ArbComplex}, Clong), z, x, P)
     return z
 end
 
@@ -373,7 +372,6 @@ function Base.angle(x::ArbComplex{P}) where {P}
     x = hypot(rea + 1.0, ima)
 
     a = 2 * atan(y , x)
-         
     T = ArbFloat{P}
     !(signbit(a) || signbit(T(pi) - a)) ? a : (signbit(a) ? zero(T) : T(pi))
 end
@@ -402,8 +400,8 @@ copysign(x::ArbComplex{P}, y::T) where {P, T<:ArbReal} =
 # a type specific hash function helps the type to 'just work'
 const hash_arbcomplex_lo = (UInt === UInt64) ? 0x76143ad985246e79 : 0x5b6a64dc
 const hash_0_arbcomplex_lo = hash(zero(UInt), hash_arbcomplex_lo)
-Base.hash(z::ArbComplex{P}, h::UInt) where {P} =
-    hash(z.real_mid_d1 ⊻ z.real_rad_exp ⊻ z.imag_mid_d1 ⊻ z.imag_rad_exp,     
-           h ⊻ hash(z.real_mid_d2 ⊻ (~reinterpret(UInt,P)), hash_arbcomplex_lo)
-               ⊻ hash_0_arbcomplex_lo)
-    
+function Base.hash(z::ArbComplex{P}, h::UInt) where {P}
+    hash(z.real_mid_d1 ⊻ z.real_rad_exp ⊻ z.imag_mid_d1 ⊻ z.imag_rad_exp,
+         h ⊻ hash(z.real_mid_d2 ⊻ (~reinterpret(UInt,P)), hash_arbcomplex_lo)
+         ⊻ hash_0_arbcomplex_lo)
+end

--- a/src/libarb/ArbComplex.jl
+++ b/src/libarb/ArbComplex.jl
@@ -161,14 +161,6 @@ end
 
 deepcopy(x::ArbComplex{P}) where {P} = copy(x)
 
-# for backward compatibility (Arb does not support rounding modes)
-function ArbComplex{P}(x::ArbComplex{Q}, ::RoundingMode=RoundNearest) where {P,Q}
-    z = ArbComplex{P}()
-    res = ccall(@libarb(acb_set_round), Cvoid,
-                (Ref{ArbComplex}, Ref{ArbComplex}, Clong), z, x, P)
-    return z
-end
-
 ArbComplex(x::ArbFloat{P}) where {P} = ArbComplex{P}(x)
 ArbComplex(x::ArbReal{P}) where {P} = ArbComplex{P}(x)
 ArbComplex(x::ArbFloat{P}, y::ArbFloat{P}) where {P} = ArbComplex{P}(x,y)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,3 +1,14 @@
-@testset "complex" begin
-  @test (1 + im) / ArbNumerics.ArbComplex(1, 1) == 1
+@testset "ArbComplex" begin
+
+    @testset "complex" begin
+        @test (1 + im) / ArbNumerics.ArbComplex(1, 1) == 1
+    end
+
+    # issue 34 and similar Cint-related stuff
+    @testset "ArbComplex constructors" begin
+        @test ArbComplex(Int32(-1)) == ArbComplex(-1.0)
+        @test ArbComplex(Int32(-1), Int32(-2)) == ArbComplex(-1.0, -2.0)
+        @test ArbComplex(typemax(Int32) + 1) == ArbComplex(float(typemax(Int32) + 1))
+    end
+
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -6,9 +6,15 @@
 
     # issue 34 and similar Cint-related stuff
     @testset "ArbComplex constructors" begin
+        @test_throws ErrorException ArbComplex(5.0, base = 3)
+        @test_throws ErrorException ArbComplex(5.0,1.0, base = 3)
+        @test ArbComplex(5, digits = 53) == ArbComplex{53}(5)
+        @test ArbComplex(5, 0, digits = 53) == ArbComplex{53}(5, 0)
+        @test ArbComplex{53}(1 + 2im) == 1 + 2im
         @test ArbComplex(Int32(-1)) == ArbComplex(-1.0)
         @test ArbComplex(Int32(-1), Int32(-2)) == ArbComplex(-1.0, -2.0)
         @test ArbComplex(typemax(Int32) + 1) == ArbComplex(float(typemax(Int32) + 1))
+        @test hash(ArbComplex(-2, -2)) isa UInt
     end
 
 end


### PR DESCRIPTION
Solves Issue #34.
The C-library is using type Int64 to pass integers in general.
A call to `acb_set_round` did provide a rounding mode argument, which is not needed (used).