### PR TITLE
libarb is merged into FLINT

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,14 +17,8 @@ Readables = "0d4725de-cd7c-5e44-8a85-a48caeef9fa5"
 GMP_jll = "781609d7-10c4-51f6-84f2-b8444358ff6d"
 MPFR_jll = "3a97d323-0669-5f0c-9066-3539efd106a3"
 FLINT_jll = "e134572f-a0d5-539d-bddf-3cad8db41a82"
-Arb_jll = "d9960996-1013-53c9-9ba4-74a4155039c3"
 
 [compat]
-Arb_jll = "~200.2300.000"
-FLINT_jll = "^200.900.000"
-SpecialFunctions = "1, 2.0, 2.1, 2.2, 2.3, 2.4"
-GenericLinearAlgebra = "0.2.5, 0.3, 0.4, 0.5, 0.6"
-Readables = "0.3"
 julia = "1"
 
 [extras]

--- a/src/ArbNumerics.jl
+++ b/src/ArbNumerics.jl
@@ -127,14 +127,14 @@ import SpecialFunctions: gamma, lgamma, lfact, digamma, invdigamma, polygamma, t
      besselj, besselj0, besselj1, bessely, bessely0, bessely1, besseli, besselk,
      eta, zeta
 
-using Arb_jll
+using FLINT_jll
 
 macro libarb(function_name)
-    return (:($function_name), libarb)
+    return (:($function_name), FLINT_jll.libflint)
 end
 
 macro libflint(function_name)
-    return (:($function_name), Arb_jll.libflint)
+    return (:($function_name), FLINT_jll.libflint)
 end
 
 using  GenericLinearAlgebra


### PR DESCRIPTION
Updating MacOS to 15.4 gave me an error loading `Arb_jll`. Details are [here](https://discourse.julialang.org/t/arb-jll-fails-to-load-precompile-dylib-after-macos-update/127989).

However, instead of trying to make `Arb_jll` work, consider that the [arblib](https://arblib.org/) website says that `Arb was merged into [FLINT](https://flintlib.org/) in 2023.`

Thus, this proposal simply uses FLINT instead of Arb. This PR is incomplete, but tests pass at least. Let me know what you think.

EDIT: fix arblib website link