### PR TITLE
prevent adding methods to the functions `>` and `>=`

### DIFF
--- a/src/values/compare.jl
+++ b/src/values/compare.jl
@@ -69,7 +69,7 @@ end
 # ArbComplex comparisons < > <= >=
 
 
-for F in (:(==), :(<), :(<=), :isequal, :isless)
+for F in (:(==), :(<), :(<=), :(>=), :(>), :isequal, :isless)
     @eval begin
         $F(x::ArbFloat{P}, y::T) where {P, T<:Integer} =
             $F(promote(x, y)...,)


### PR DESCRIPTION
As documented, the intended way to implement `>` is to add a method to `<`. Similarly with `>=`. A package should never add a method to either `>` or `>=`.

The `!=` function should also usually not get any new methods.

EDIT: some of the methods here behave differently than Julia's generic fallback. These methods are preserved with this change to prevent breakage.